### PR TITLE
GSoC 2024: Propagate Metadata (FFmpeg)

### DIFF
--- a/libavfilter/vf_libvmaf.c
+++ b/libavfilter/vf_libvmaf.c
@@ -475,7 +475,6 @@ static av_cold int init(AVFilterContext *ctx)
     VmafMetadataConfig meta_cfg = {
         .callback = set_meta,
         .data = s->meta_data,
-        .data_sz = sizeof(*s->meta_data),
     };
 
     err = vmaf_register_metadata_callback(s->vmaf, &meta_cfg);

--- a/libavfilter/vf_libvmaf.c
+++ b/libavfilter/vf_libvmaf.c
@@ -117,7 +117,7 @@ static void dump_metadata(void *data, AVDictionary *metadata)
     MetaStruct *meta_data = data;
 
     while ((tag = av_dict_get(metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
-        av_log(NULL, AV_LOG_DEBUG, "VMAF feature: %s, score: %s\n",
+        av_log(NULL, AV_LOG_INFO, "VMAF feature: %s, score: %s\n",
                tag->key, tag->value);
         av_dict_set(meta_data->metadata, tag->key, tag->value, 0);
     }
@@ -130,7 +130,7 @@ static void set_meta(void *data, VmafMetadata *metadata)
     snprintf(value, sizeof(value), "%0.2f", metadata->score);
     snprintf(key, sizeof(key), "%s_%d", metadata->feature_name, metadata->picture_index);
     av_dict_set(meta_data->metadata, key, value, 0);
-    av_log(NULL, AV_LOG_DEBUG, "VMAF feature: %s, score: %f\n",
+    av_log(NULL, AV_LOG_INFO, "VMAF feature: %s, score: %f\n",
            key, metadata->score);
 }
 
@@ -482,7 +482,7 @@ static av_cold int init(AVFilterContext *ctx)
         .data = s->meta_data,
     };
 
-    err = vmaf_register_metadata_callback(s->vmaf, meta_cfg);
+    err = vmaf_register_metadata_handler(s->vmaf, meta_cfg);
     if (err) {
         return AVERROR(EINVAL);
     }
@@ -493,7 +493,7 @@ static av_cold int init(AVFilterContext *ctx)
         .data = s->meta_data,
     };
 
-    err = vmaf_register_metadata_callback(s->vmaf, meta_cfg_1);
+    err = vmaf_register_metadata_handler(s->vmaf, meta_cfg_1);
     if (err) {
         return AVERROR(EINVAL);
     }

--- a/libavfilter/vf_libvmaf.c
+++ b/libavfilter/vf_libvmaf.c
@@ -46,6 +46,11 @@
 #include "libavutil/hwcontext_cuda_internal.h"
 #endif
 
+typedef struct MetaStruct {
+    AVDictionary **metadata;
+    char comp;
+} MetaStruct;
+
 typedef struct LIBVMAFContext {
     const AVClass *class;
     FFFrameSync fs;
@@ -57,6 +62,7 @@ typedef struct LIBVMAFContext {
     char *model_cfg;
     char *feature_cfg;
     AVDictionary *metadata;
+    MetaStruct *meta_data;
     VmafContext *vmaf;
     VmafModel **model;
     unsigned model_cnt;
@@ -105,11 +111,6 @@ static enum VmafPixelFormat pix_fmt_map(enum AVPixelFormat av_pix_fmt)
         return VMAF_PIX_FMT_UNKNOWN;
     }
 }
-
-typedef struct MetaStruct {
-    AVDictionary **metadata;
-    char comp;
-} MetaStruct;
 
 //static void set_meta(AVDictionary **metadata, const char *key, char comp, float d)
 static void set_meta(void *data, const char *key, double d)
@@ -454,23 +455,33 @@ static av_cold int init(AVFilterContext *ctx)
     LIBVMAFContext *s = ctx->priv;
     int err = 0;
 
-    MetaStruct meta_data = {
-        .metadata = &s->metadata,
-        .comp     = 0,
-    };
-
     VmafConfiguration cfg = {
         .log_level = log_level_map(av_log_get_level()),
         .n_subsample = s->n_subsample,
         .n_threads = s->n_threads,
-        .callback = set_meta,
-        .meta_data = &meta_data,
-        .meta_data_sz = sizeof(meta_data),
     };
 
     err = vmaf_init(&s->vmaf, cfg);
     if (err)
         return AVERROR(EINVAL);
+
+    s->meta_data = malloc(sizeof(*s->meta_data));
+    if (err)
+        return AVERROR(ENOMEM);
+
+    s->meta_data->metadata = &s->metadata;
+    s->meta_data->comp     = 0;
+
+    VmafMetadataConfig meta_cfg = {
+        .callback = set_meta,
+        .data = s->meta_data,
+        .data_sz = sizeof(*s->meta_data),
+    };
+
+    err = vmaf_register_metadata_callback(s->vmaf, &meta_cfg);
+    if (err) {
+        return AVERROR(EINVAL);
+    }
 
     err = parse_models(ctx);
     if (err)


### PR DESCRIPTION
This is part of GSoC 2024.

Add metadata propagation for FFmpeg/libvmaf filter, according to changes made [here](https://github.com/Netflix/vmaf/pull/1374)